### PR TITLE
Fix handling of homs with trivial range / source

### DIFF
--- a/lib/Hom.gi
+++ b/lib/Hom.gi
@@ -43,12 +43,12 @@ InstallMethod( ImagesRepresentative,
 
 InstallMethod( FGA_Source,
    [ IsFromFpGroupGeneralMappingByImages and HasMappingGeneratorsImages ],
-   hom -> Group( MappingGeneratorsImages(hom)[1] )
+   hom -> Subgroup( Source(hom), MappingGeneratorsImages(hom)[1] )
 );
 
 InstallMethod( FGA_Image,
    [ IsToFpGroupGeneralMappingByImages and HasMappingGeneratorsImages ],
-   hom -> Group( MappingGeneratorsImages(hom)[2] )
+   hom -> Subgroup( Range(hom), MappingGeneratorsImages(hom)[2] )
 );
 
 InstallMethod( IsSingleValued,
@@ -60,7 +60,7 @@ InstallMethod( IsSingleValued,
 
    if mgi[1]=[] then return true; fi; # map on trivial group
 
-   g := Group( mgi[1] );
+   g := Subgroup( Source(hom), mgi[1] );
    if not IsFreeGroup( g ) then
       TryNextMethod();
    fi;

--- a/tst/FGA.tst
+++ b/tst/FGA.tst
@@ -63,4 +63,10 @@ gap> iso := GroupHomomorphismByImages(f,f,[f.1*f.2,f.1*f.2^2],[f.2^2*f.1,f.2*f.1
 gap> SetIsSurjective(iso,true);
 gap> Image(iso,PreImagesRepresentative(iso,f.1));
 f1
+gap> # bug with trivial image / preimage
+gap> F:=FreeGroup(0);;
+gap> homFree:=GroupHomomorphismByImages(F, F, [], []);
+[  ] -> [  ]
+gap> PreImagesRepresentative(homFree, One(F));
+<identity ...>
 gap> STOP_TEST( "FGA.tst", 100000);


### PR DESCRIPTION
This fixes an issue with homomorphisms whose source or range is a trivial free group. See gap-system/gap#445
