### PR TITLE
Switch testall.g to use TestDirectory

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -113,7 +113,7 @@ PackageDoc := rec(
 ##  Are there restrictions on the operating system for this package? Or does
 ##  the package need other packages to be available?
 Dependencies := rec(
-  GAP := ">=4.4",
+  GAP := ">=4.8",
   NeededOtherPackages := [],
   SuggestedOtherPackages := [],
   ExternalConditions := []

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,3 +1,3 @@
-LoadPackage( "FGA" );
-dirs := DirectoriesPackageLibrary( "FGA", "tst" );
-ReadTest( Filename( dirs, "FGA.tst" ) );
+LoadPackage("FGA");
+TestDirectory(DirectoriesPackageLibrary("FGA", "tst"), rec(exitGAP := true));
+FORCE_QUIT_GAP(1);


### PR DESCRIPTION
This has the advantage that the tests produce an exit code indicating the
status of the tests, and also uniform defined output, both of which we can be
checked in an automated fashion for the GAP distribution.