### PR TITLE
Avoid InstallValue for complex objects

### DIFF
--- a/lib/ExtAutom.gd
+++ b/lib/ExtAutom.gd
@@ -8,9 +8,6 @@
 #Y  2003 - 2012
 ##
 
-DeclareGlobalVariable( "FGA_FreeGroupForGenerators" );
-DeclareGlobalVariable( "FGA_One" );
-
 DeclareGlobalFunction( "FGA_newstateX" );
 DeclareGlobalFunction( "FGA_connectposX" );
 DeclareGlobalFunction( "FGA_connectX" );

--- a/lib/ExtAutom.gi
+++ b/lib/ExtAutom.gi
@@ -8,9 +8,9 @@
 ##
 
 
-InstallValue( FGA_FreeGroupForGenerators, FreeGroup(infinity) );
+BindGlobal( "FGA_FreeGroupForGenerators", FreeGroup(infinity) );
 
-InstallValue( FGA_One, One(FGA_FreeGroupForGenerators) );
+BindGlobal( "FGA_One", One(FGA_FreeGroupForGenerators) );
 
 InstallGlobalFunction( FGA_newstateX,
     function()


### PR DESCRIPTION
For objects other than plain lists, strings and records, InstallValue is a problematic operation as it has to deep clone the installed value. The GAP team is therefore trying to get rid of all uses of it that install complex values.

See also https://github.com/gap-system/gap/issues/1637#issuecomment-1200514668